### PR TITLE
fixed direction of sequential combinator

### DIFF
--- a/src/main/scala/wolfendale/scalacheck/regexp/GenParser.scala
+++ b/src/main/scala/wolfendale/scalacheck/regexp/GenParser.scala
@@ -142,7 +142,7 @@ object GenParser extends RegexParsers with PackratParsers {
   lazy val regularExpression: Parser[RegularExpression] = {
     bos ~> expression <~ eos ^^ { expr => And(And(BOS, expr), EOS) } |
     bos ~> expression        ^^ { expr => And(BOS, expr) } |
-    expression ~> eos        ^^ { expr => And(expr, EOS) } |
+    expression <~ eos        ^^ { expr => And(expr, EOS) } |
     expression
   }
 

--- a/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
+++ b/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
@@ -3,7 +3,7 @@ package wolfendale.scalacheck.regexp
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{MustMatchers, WordSpec}
-import ast.{CharacterClass, _}
+import ast._
 
 class GenParserSpec extends WordSpec with MustMatchers with PropertyChecks {
 

--- a/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
+++ b/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
@@ -3,7 +3,7 @@ package wolfendale.scalacheck.regexp
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{MustMatchers, WordSpec}
-import ast._
+import ast.{CharacterClass, _}
 
 class GenParserSpec extends WordSpec with MustMatchers with PropertyChecks {
 
@@ -337,6 +337,12 @@ class GenParserSpec extends WordSpec with MustMatchers with PropertyChecks {
 
     "parse a negated character class" in {
       GenParser.parse("[^abc]") mustEqual Negated(CharacterClass(CharacterClass.Literal("a"), CharacterClass.Literal("b"), CharacterClass.Literal("c")))
+    }
+
+    "parse input containing EOS character" in {
+      forAll(neAlphaNum) { a =>
+        GenParser.parse(a + "$") mustEqual And(Literal(a), EOS)
+      }
     }
   }
 }


### PR DESCRIPTION
Direction for sequential combinator was pointing in the wrong direction so instead of producing a `And(Literal(xxx), EOS)` it was producing a `And(EOS, EOS)` and throwing away the wrong result