### PR TITLE
Character Class Intersections

### DIFF
--- a/src/main/scala/wolfendale/scalacheck/regexp/ASTProcessor.scala
+++ b/src/main/scala/wolfendale/scalacheck/regexp/ASTProcessor.scala
@@ -117,6 +117,8 @@ object ASTProcessor {
         spaceChar
       case CharacterClass.DigitChar =>
         digitChar
+      case term@CharacterClass.Intersection(_, _, _) =>
+        Gen.oneOf(CharacterClass.toSet(term).map(_.toString).toList)
       case _ =>
         Gen.const("")
     }

--- a/src/main/scala/wolfendale/scalacheck/regexp/GenParser.scala
+++ b/src/main/scala/wolfendale/scalacheck/regexp/GenParser.scala
@@ -112,14 +112,14 @@ object GenParser extends RegexParsers with PackratParsers {
         case x: CharacterClass.Term => CharacterClass(x)
       }
 
-    lazy val classOrTerms1: Parser[(CharacterClass, List[CharacterClass])] =
+    lazy val intersections1: Parser[(CharacterClass, List[CharacterClass])] =
       "&&" ~> rep1sep(classOrTerm, "&&") ^^ {
         case x :: ys => (x, ys)
         case _ => sys.error("Unreachable code reached")
       }
 
-    lazy val intersection: Parser[CharacterClass] =
-      "[" ~ characterClassTerm ~ classOrTerms1 ~ "]" ^^ {
+    lazy val intersections: Parser[CharacterClass] =
+      "[" ~ characterClassTerm ~ intersections1 ~ "]" ^^ {
         case _ ~ left ~ ((right, remaining)) ~ _ =>
           CharacterClass(CharacterClass.Intersection(left, right, remaining: _*))
       }
@@ -129,7 +129,7 @@ object GenParser extends RegexParsers with PackratParsers {
     lazy val negatedCharClass =
       ("[^" ~> characterClassTerm.+ <~ "]") ^^ { terms => Negated(CharacterClass(terms: _*)) }
 
-    intersection | negatedCharClass | charClass
+    intersections | negatedCharClass | charClass
   }
 
   // terminals...

--- a/src/main/scala/wolfendale/scalacheck/regexp/GenParser.scala
+++ b/src/main/scala/wolfendale/scalacheck/regexp/GenParser.scala
@@ -121,7 +121,7 @@ object GenParser extends RegexParsers with PackratParsers {
     lazy val intersections: Parser[CharacterClass] =
       "[" ~ characterClassTerm ~ intersections1 ~ "]" ^^ {
         case _ ~ left ~ ((right, remaining)) ~ _ =>
-          CharacterClass(CharacterClass.Intersection(left, right, remaining: _*))
+          CharacterClass(CharacterClass.Intersection(left, right, remaining))
       }
 
     lazy val charClass =

--- a/src/main/scala/wolfendale/scalacheck/regexp/ast/AST.scala
+++ b/src/main/scala/wolfendale/scalacheck/regexp/ast/AST.scala
@@ -50,6 +50,8 @@ object CharacterClass {
   case object DigitChar extends Term
   case object SpaceChar extends Term
   case object WordBoundary extends Term
+
+  case class Intersection(left: Term, right: CharacterClass, remaining: CharacterClass*) extends Term
 }
 
 case class CharacterClass(terms: CharacterClass.Term*) extends RegularExpression

--- a/src/test/scala/wolfendale/scalacheck/regexp/ASTProcessorSpec.scala
+++ b/src/test/scala/wolfendale/scalacheck/regexp/ASTProcessorSpec.scala
@@ -377,5 +377,19 @@ class ASTProcessorSpec extends WordSpec with MustMatchers with PropertyChecks {
           }
       }
     }
+
+    "generate a character class with an intersection" in {
+
+      val genGen: Gen[String] = ASTProcessor.apply(CharacterClass(
+        CharacterClass.Intersection(
+          CharacterClass.CharRange('a', 'z'),
+          CharacterClass(CharacterClass.CharRange('b', 'y')),
+          List(CharacterClass(CharacterClass.WordChar))))
+      )
+
+      forAll(genGen) { str =>
+        str must fullyMatch regex "[a-z&&[b-y]&&[\\w]]"
+      }
+    }
   }
 }

--- a/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
+++ b/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
@@ -341,12 +341,12 @@ class GenParserSpec extends WordSpec with MustMatchers with PropertyChecks {
 
     "parse a character class intersection" in {
       GenParser.parse("[a&&b]") mustEqual
-        CharacterClass(CharacterClass.Intersection(CharacterClass.Literal("a"), CharacterClass(CharacterClass.Literal("b"))))
+        CharacterClass(CharacterClass.Intersection(CharacterClass.Literal("a"), CharacterClass(CharacterClass.Literal("b")), Nil))
     }
 
     "parse a nested character class intersection" in {
       GenParser.parse("[a&&[b]]") mustEqual
-        CharacterClass(CharacterClass.Intersection(CharacterClass.Literal("a"), CharacterClass(CharacterClass.Literal("b"))))
+        CharacterClass(CharacterClass.Intersection(CharacterClass.Literal("a"), CharacterClass(CharacterClass.Literal("b")), Nil))
     }
 
     "parse multiple nested character class intersections" in {
@@ -354,7 +354,7 @@ class GenParserSpec extends WordSpec with MustMatchers with PropertyChecks {
         CharacterClass(CharacterClass.Intersection(
           CharacterClass.Literal("a"),
           CharacterClass(CharacterClass.Literal("b")),
-          CharacterClass(CharacterClass.Literal("c"))))
+          List(CharacterClass(CharacterClass.Literal("c")))))
     }
   }
 }

--- a/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
+++ b/src/test/scala/wolfendale/scalacheck/regexp/GenParserSpec.scala
@@ -338,5 +338,23 @@ class GenParserSpec extends WordSpec with MustMatchers with PropertyChecks {
     "parse a negated character class" in {
       GenParser.parse("[^abc]") mustEqual Negated(CharacterClass(CharacterClass.Literal("a"), CharacterClass.Literal("b"), CharacterClass.Literal("c")))
     }
+
+    "parse a character class intersection" in {
+      GenParser.parse("[a&&b]") mustEqual
+        CharacterClass(CharacterClass.Intersection(CharacterClass.Literal("a"), CharacterClass(CharacterClass.Literal("b"))))
+    }
+
+    "parse a nested character class intersection" in {
+      GenParser.parse("[a&&[b]]") mustEqual
+        CharacterClass(CharacterClass.Intersection(CharacterClass.Literal("a"), CharacterClass(CharacterClass.Literal("b"))))
+    }
+
+    "parse multiple nested character class intersections" in {
+      GenParser.parse("[a&&[b]&&[c]]") mustEqual
+        CharacterClass(CharacterClass.Intersection(
+          CharacterClass.Literal("a"),
+          CharacterClass(CharacterClass.Literal("b")),
+          CharacterClass(CharacterClass.Literal("c"))))
+    }
   }
 }


### PR DESCRIPTION
Raising PR more to discuss the approach and see if there is a better way to accomplish this.

The `Term` AST has been expanded to include an intersection type.
Valid character class intersections are:
  `[a&&b]`
  `[a&&[b]]`
  `[a&&b&&[c]]`
  `[a&&[b]&&[c]]`

The Intersection type enforces this requiring a `Term` and at least 1 `CharacterClass` but can contain more. `Term`s are valid in place of `CharacterClass`s and the `GenParser` converts all `Term`s to `CharacterClass`s to account for this.

The `ASTProcessor` uses sets of values to produce a final list of values that the generator can produce. The `toSet` methods on the `CharacterClass` companion object converts the `Term` AST to sets of values and in the case of `WordBoundry` it uses all the possible values of `Char` as the basis, this is the part I am not entirely sure of as I am not sure of the total size of the set and whether this should be of concern. The benefit of doing it this way is that we do not rely on `.suchThat` which can throw away too many tests. This way the only time data will fail to generate is if the regex is bad
